### PR TITLE
replaced response with request

### DIFF
--- a/callback/php/callback.php
+++ b/callback/php/callback.php
@@ -30,7 +30,7 @@ $res = array(
     'operator' => $operator,
     'payload' => array(
         'request_id' => $request_id,
-        'response' => $request,
+        'request' => $request,
     ),
 );
 


### PR DESCRIPTION
The key named response should be replaced as request, otherwise, the USSD menu will be returned as null